### PR TITLE
Add support for ESP32, add optional debug logs via serial and MQTT, fix ifeel, improve handlers to support more HA sommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,37 @@ Monitoring and getting the real state of the AC is also possible by subscribing 
 
 ### Home Assistant
 
-Home Assistant's MQTT HVAC component can be used with the following configuration:
+Since Home Assistant 2022.6, MQTT entities are configured under the top-level `mqtt:` key in `configuration.yaml` rather than using `platform: mqtt` inside each domain. The examples below use this new style.
+
+#### Device grouping and YAML anchors
+
+All entities (climate, iFeel switch, reboot button) belong to the same logical device — the ESP controller. To avoid repeating the device block and to group them together in the HA device registry, define it once using a **YAML anchor** (`&main_ac_device`) and reference it in the other entities with an **alias** (`*main_ac_device`):
 
 ```yaml
-climate:
-  - platform: mqtt
-    name: AC
+device: &main_ac_device   # defines the anchor
+  identifiers: "main_ac"  # unique ID that groups all entities into one device
+  manufacturer: "Electra"
+  name: "Main AC"
+
+# later, in another entity:
+device: *main_ac_device   # reuses the exact same block
+```
+
+All entities sharing the same `identifiers` value will appear under one device card in **Settings → Devices & Services → MQTT**.
+
+---
+
+#### Climate (AC control)
+
+```yaml
+mqtt:
+  climate:
+    name: AC MQTT
+    unique_id: mqtt_ac_esp
+    device: &main_ac_device
+      identifiers: "main_ac"
+      manufacturer: "Electra"
+      name: "Main AC"
     modes:
       - "heat"
       - "cool"
@@ -145,16 +170,35 @@ climate:
     swing_mode_state_topic: "devices/AC/swing/state"
 ```
 
-It's possible to activate the iFeel by using the build-in aux-heat or away_mode topic for the MQTT HVAC component by adding the following lines:
-Its not ideal as it will show "Preset: Home/Away" but it works fine.
+#### iFeel switch
+
+iFeel is exposed as a dedicated MQTT switch (cleaner than the old `away_mode` hack which showed "Preset: Home/Away"):
 
 ```yaml
-climate:
-    ...
-    ...
-    away_mode_command_topic: "devices/AC/ifeel/state/set"
-    away_mode_state_topic: "devices/AC/ifeel/state"
+  switch:
+    name: "AC iFeel"
+    unique_id: main_ac_ifeel
+    device: *main_ac_device
+    icon: mdi:home-thermometer-outline
+    command_topic: "devices/AC/ifeel/state/set"
+    state_topic: "devices/AC/ifeel/state"
+    payload_on: "on"
+    payload_off: "off"
 ```
+
+#### Reboot button
+
+```yaml
+  button:
+    name: "AC Controller Reboot"
+    unique_id: ac_esp_reboot
+    device: *main_ac_device
+    icon: mdi:restart
+    command_topic: "devices/AC/reboot/trigger/set"
+    payload_press: "true"
+```
+
+> **Note:** The `mqtt:` key must appear only once in `configuration.yaml`. Place `climate:`, `switch:`, and `button:` as siblings under it. The YAML anchor `&main_ac_device` must be defined before it is referenced with `*main_ac_device`, so the `climate:` block (where the anchor is declared) must come first.
 
 ### Home Assistant - Lovelace UI
 
@@ -231,31 +275,6 @@ automation:
         payload: "{{ states('sensor.<tempereture-sensor>') }}"
 ```
 Note: The protocol only supports integer values, so the temperature will be rounded down.
-
-### Home Assistant - Remote reboot
-
-To add a reboot button in Home Assistant, add the following to your `configuration.yaml`:
-
-```yaml
-button:
-  - platform: mqtt
-    name: "AC Contoller Reboot"
-    command_topic: "devices/AC/reboot/trigger/set"
-    payload_press: "true"
-```
-
-Alternatively, use a script or automation:
-
-```yaml
-script:
-  reboot_ac:
-    alias: Reboot AC ESP
-    sequence:
-      - service: mqtt.publish
-        data:
-          topic: "devices/AC/reboot/trigger/set"
-          payload: "true"
-```
 
 ### Credits
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ In addition, there are dependencies conflicts bewtween `Async TCP` and `AsyncTCP
 After the esp is configured, it will subscribe to the following MQTT topics:
 - .../state/json/set 
   - This topic accepts a json in the following format (all fields are mandatory), updates the state and send it to the AC unit:   
-  `{"power": "on|off", "mode": "cool|heat|fan|dry|auto", "fan": "low|med|high|auto", "temperature": 15..30, "ifeel": "on|off", "swing":"on|off|hor|both"}`
+  `{"power": "on|off", "mode": "cool|heat|fan_only|dry|auto", "fan": "low|med|high|auto", "temperature": 15..30, "ifeel": "on|off", "swing":"on|off|hor|both"}`
+  > Note: `"fan"` is also accepted as an alias for `"fan_only"` for backward compatibility.
 - .../ifeel_temperature/state/set
   - This topic accepts a number between 5 and 36 and sends it to the main unit as a temperature received by the "i feel" function of the remote.
   
@@ -115,6 +116,7 @@ climate:
       - "heat"
       - "cool"
       - "dry"
+      - "fan_only"
       - "off"
     fan_modes:
       - "high"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ After the esp is configured, it will subscribe to the following MQTT topics:
   > Note: `"fan"` is also accepted as an alias for `"fan_only"` for backward compatibility.
 - .../ifeel_temperature/state/set
   - This topic accepts a number between 5 and 36 and sends it to the main unit as a temperature received by the "i feel" function of the remote.
+- .../reboot/trigger/set
+  - Publish `true` to this topic to reboot the device remotely.
   
 Monitoring and getting the real state of the AC is also possible by subscribing to the following topics:
 - .../power/state
@@ -229,6 +231,31 @@ automation:
         payload: "{{ states('sensor.<tempereture-sensor>') }}"
 ```
 Note: The protocol only supports integer values, so the temperature will be rounded down.
+
+### Home Assistant - Remote reboot
+
+To add a reboot button in Home Assistant, add the following to your `configuration.yaml`:
+
+```yaml
+button:
+  - platform: mqtt
+    name: "AC Contoller Reboot"
+    command_topic: "devices/AC/reboot/trigger/set"
+    payload_press: "true"
+```
+
+Alternatively, use a script or automation:
+
+```yaml
+script:
+  reboot_ac:
+    alias: Reboot AC ESP
+    sequence:
+      - service: mqtt.publish
+        data:
+          topic: "devices/AC/reboot/trigger/set"
+          payload: "true"
+```
 
 ### Credits
 

--- a/README.md
+++ b/README.md
@@ -223,9 +223,10 @@ automation:
     action:
       service: mqtt.publish
       data:
-        topic: "homie/<homie-id>/ifeel_temperature/state/set"
-        payload_template: "{{ states.sensor.<my-tempereture-sensor>.state }}"
+        topic: "devices/AC/ifeel-temperature/state/set"
+        payload: "{{ states('sensor.<tempereture-sensor>') }}"
 ```
+Note: The protocol only supports integer values, so the temperature will be rounded down.
 
 ### Credits
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ Once the code is installed on the esp, it will boot in configuration mode. Follo
 A sample json config file is provided under `/data/homie/config.json`. This file can be edited and uploaded using platform.io under "Platform -> Build Filesystem Image" and the "Platform -> Upload Filesystem Image". Make sure to properly edit the file before uploading.
 
 ### Building
-Building with platform.io is quite simple. But Homie is not compatible with Platform.io 3.0 for ESP8266 out of the box. You need to change two files in the Homie library.
+Building with platform.io is quite simple. But Homie is not compatible with Platform.io 3.0 for ESP8266 and ESP32 out of the box. You need to change files in the Homie library: `./pio/libdeps/`<target>`/Homie/src/Homie/Boot`.
+#### ESP8266
 - Start building as usual. You will see some errors regarding the "HTTPClient" calls not being supported.
-- Navigate to the ./pio/libdeps/<target>/Homie/src/Homie/Boot
+- Navigate to the ./pio/libdeps/`<target>`/Homie/src/Homie/Boot
 - Edit the `BootConfig.hpp` and `BootConfig.cpp` files as follows:
 
 - BootConfig.hpp
@@ -74,7 +75,17 @@ so that it looks as follows:
   // copy headers
 ```
 
+#### ESP32
+For esp32 support you need to edit Homie either.
+After trying to build, you will see errors regarding arduino events.
+Open `BootNormal.cpp` and replace these strings:
 
+- replace: `WiFiEvent_t::SYSTEM_EVENT_STA_GOT_IP` with: `ARDUINO_EVENT_WIFI_STA_GOT_IP`
+- replace: `WiFiEvent_t::SYSTEM_EVENT_STA_DISCONNECTED` with: `ARDUINO_EVENT_WIFI_STA_DISCONNECTED`
+- replace: `info.disconnected.reason` with: `info.wifi_sta_disconnected.reason` (2 occurrences)
+
+
+In addition, there are dependencies conflicts bewtween `Async TCP` and `AsyncTCP` libraries, since `ESP Async WebServer` requires the first and `AsyncMqttClient` the last, but they use the same function names. adding `Async TCP` to `lib_ignore ` on `platformio.ini` should solve this, but if in the future you have linking errors with `AsyncTCP` - try to seek there for the cause.
 
 ## Usage
 After the esp is configured, it will subscribe to the following MQTT topics:

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,6 +8,19 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+upload_protocol = esptool
+framework = arduino
+build_flags = -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+lib_deps = 
+	ArduinoJson@<6.17
+	IRremoteESP8266
+	marvinroger/Homie@^3.0.1
+	ESP32Async/AsyncTCP@^3.3.5
+monitor_speed = 115200
+
 [env:esp12e]
 ; target ARDUINO_ESP8266_ESP12
 platform = espressif8266@2.5.0
@@ -17,7 +30,10 @@ upload_protocol = esptool
 framework = arduino
 ; ADD -D ELECTRAWIFI_NO_IR_RCV  to remove the IR reception code
 build_flags = -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
-lib_deps = ArduinoJson@<6.17, Homie@3.0.1, IRremoteESP8266 
+lib_deps = 
+	ArduinoJson@<6.17
+	IRremoteESP8266
+	marvinroger/Homie@^3.0.1
 monitor_speed = 115200
 
 
@@ -30,8 +46,10 @@ platform = espressif8266
 board = esp01_1m
 upload_protocol = esptool
 framework = arduino
-; ADD -D ELECTRAWIFI_NO_IR_RCV  to remove the IR reception code
-build_flags = -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY 
-lib_deps = ArduinoJson@<6.17, Homie@3.0.1, IRremoteESP8266 
+build_flags = -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+lib_deps = 
+	ArduinoJson@<6.17
+	IRremoteESP8266
+	marvinroger/Homie@^3.0.1
 monitor_speed = 115200
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,9 @@ lib_deps =
 	ArduinoJson@<6.17
 	IRremoteESP8266
 	marvinroger/Homie@^3.0.1
-	ESP32Async/AsyncTCP@^3.3.5
+lib_ignore = 
+	Async TCP
+		; This has a space and conflicts with AsyncTCP (no space) which is required by Homie
 monitor_speed = 115200
 
 [env:esp12e]

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,11 @@ build_flags =
 	-D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
 	-D DEBUG_SERIAL=0 	; Set to 1 for serial logging (USB debugging), 0 for production
 	-D DEBUG_MQTT=1 	; Set to 1 for MQTT logging (wireless debugging), 0 to disable. Subscribe to devices/+/debug/log in your MQTT broker to see logs
+	-D PIN_POWER=5
+	-D PIN_IR=4
+	-D PIN_GREEN_LED=12
+	-D PIN_RED_LED=15
+	-D PIN_IR_RECV=14
 lib_deps = 
 	ArduinoJson@<6.17
 	IRremoteESP8266
@@ -38,6 +43,11 @@ build_flags =
 	-D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
 	-D DEBUG_SERIAL=0 	; Set to 1 for serial logging (USB debugging), 0 for production
 	-D DEBUG_MQTT=1 	; Set to 1 for MQTT logging (wireless debugging), 0 to disable. Subscribe to devices/+/debug/log in your MQTT broker to see logs
+	-D PIN_POWER=5
+	-D PIN_IR=23
+	-D PIN_GREEN_LED=12
+	-D PIN_RED_LED=13
+	-D PIN_IR_RECV=14
 lib_deps = 
 	ArduinoJson@<6.17
 	IRremoteESP8266
@@ -56,6 +66,11 @@ upload_protocol = esptool
 framework = arduino
 ; ADD -D ELECTRAWIFI_NO_IR_RCV  to remove the IR reception code
 build_flags = -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+	-D PIN_POWER=5
+	-D PIN_IR=4
+	-D PIN_GREEN_LED=12
+	-D PIN_RED_LED=15
+	-D PIN_IR_RECV=14
 lib_deps = 
 	ArduinoJson@<6.17
 	IRremoteESP8266
@@ -73,6 +88,9 @@ board = esp01_1m
 upload_protocol = esptool
 framework = arduino
 build_flags = -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+	-D PIN_POWER=2
+	-D PIN_IR=0
+	-D PIN_IR_RECV=14
 lib_deps = 
 	ArduinoJson@<6.17
 	IRremoteESP8266

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,30 @@ platform = espressif32
 board = esp32dev
 upload_protocol = esptool
 framework = arduino
-build_flags = -D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+build_flags = 
+	-D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+	-D DEBUG_SERIAL=0 	; Set to 1 for serial logging (USB debugging), 0 for production
+	-D DEBUG_MQTT=1 	; Set to 1 for MQTT logging (wireless debugging), 0 to disable. Subscribe to devices/+/debug/log in your MQTT broker to see logs
+lib_deps = 
+	ArduinoJson@<6.17
+	IRremoteESP8266
+	marvinroger/Homie@^3.0.1
+lib_ignore = 
+	Async TCP
+		; This has a space and conflicts with AsyncTCP (no space) which is required by Homie
+monitor_speed = 115200
+
+[env:esp32-devkitc-1]
+; works with ESP32-D0WD-V3 (revision v3.1) - need to explicitly set the filesystem to spiffs
+platform = espressif32
+board = esp32dev
+upload_protocol = esptool
+framework = arduino
+board_build.filesystem = spiffs
+build_flags = 
+	-D PIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+	-D DEBUG_SERIAL=0 	; Set to 1 for serial logging (USB debugging), 0 for production
+	-D DEBUG_MQTT=1 	; Set to 1 for MQTT logging (wireless debugging), 0 to disable. Subscribe to devices/+/debug/log in your MQTT broker to see logs
 lib_deps = 
 	ArduinoJson@<6.17
 	IRremoteESP8266
@@ -54,4 +77,5 @@ lib_deps =
 	IRremoteESP8266
 	marvinroger/Homie@^3.0.1
 monitor_speed = 115200
+
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32dev]
-platform = espressif32
+platform = espressif32@6.9.0
 board = esp32dev
 upload_protocol = esptool
 framework = arduino
@@ -28,7 +28,8 @@ monitor_speed = 115200
 
 [env:esp32-devkitc-1]
 ; works with ESP32-D0WD-V3 (revision v3.1) - need to explicitly set the filesystem to spiffs
-platform = espressif32
+; Might need to upload filesystem image separately: pio run --target uploadfs --environment esp32-devkitc-1	
+platform = espressif32@6.9.0
 board = esp32dev
 upload_protocol = esptool
 framework = arduino

--- a/src/IRelectra.cpp
+++ b/src/IRelectra.cpp
@@ -80,6 +80,8 @@ void IRelectra::SendElectra(bool notify) {
     // get the data representing the configuration
     uint64_t code = EncodeElectra(notify);
     
+    Serial.println("IR command sent to GPIO: 0x" + String((unsigned long)code, HEX) + (notify ? " (notify)" : ""));
+    
     // The whole packet looks this:
     //  3 Times: 
     //    3000 usec MARK
@@ -157,7 +159,7 @@ void IRelectra::UpdateFromIR(uint64_t code) {
     uint32_t send_temp;
     power_t power;
     bool notify;
-
+    
     power =     (power_t)  ((code >> 33) & 1);
     mode =      (ac_mode_t)((code >> 30) & 7);
     fan =       (fan_t)    ((code >> 28) & 3);
@@ -167,6 +169,13 @@ void IRelectra::UpdateFromIR(uint64_t code) {
     ifeel =     (ifeel_t)  ((code >> 24) & 1);
     send_temp = (ifeel_t)  ((code >> 19) & 31);
     sleep =     (sleep_t)  ((code >> 18) & 1);
+    
+    Serial.println("IR code parsed: 0x" + String((unsigned long)code, HEX) + 
+                   " | Power: " + String(power == POWER_TOGGLE ? "TOGGLE" : "KEEP") + 
+                   ", Mode: " + String(mode) + ", Fan: " + String(fan) + ", Notify: " + String(notify ? "yes" : "no") + 
+                   " | Swing_H: " + String(swing_h ? "on" : "off") + ", Swing: " + String(swing ? "on" : "off") + 
+                   ", IFeel: " + String(ifeel ? "on" : "off") + ", Sleep: " + String(sleep ? "on" : "off") + 
+                   ", Temp: " + String(notify ? send_temp + 5 : send_temp + 15));
 
     if (power == POWER_TOGGLE) {
         power_setting = !power_real;

--- a/src/IRelectra.cpp
+++ b/src/IRelectra.cpp
@@ -7,6 +7,22 @@
 #include <Arduino.h>
 #include <IRutils.h>
 
+// Debug logging callback - can be set by main.cpp
+static void (*debugLogCallback)(const String&) = nullptr;
+
+void setIRDebugCallback(void (*callback)(const String&)) {
+    debugLogCallback = callback;
+}
+
+// Debug logging - controlled by DEBUG_SERIAL and DEBUG_MQTT build flags
+#if DEBUG_SERIAL || DEBUG_MQTT
+  #define DEBUG_LOG(x) do { \
+    if (debugLogCallback) debugLogCallback(x); \
+  } while(0)
+#else
+  inline void DEBUG_LOG(const String&) { }
+#endif
+
 #define UNIT 1000
 #define TICKS_TO_UNITS(x) round((float)(x) * kRawTick / UNIT)
 
@@ -80,7 +96,7 @@ void IRelectra::SendElectra(bool notify) {
     // get the data representing the configuration
     uint64_t code = EncodeElectra(notify);
     
-    Serial.println("IR command sent to GPIO: 0x" + String((unsigned long)code, HEX) + (notify ? " (notify)" : ""));
+    DEBUG_LOG("IR command sent to GPIO: 0x" + String((unsigned long)code, HEX) + (notify ? " (notify)" : ""));
     
     // The whole packet looks this:
     //  3 Times: 
@@ -170,12 +186,12 @@ void IRelectra::UpdateFromIR(uint64_t code) {
     send_temp = (ifeel_t)  ((code >> 19) & 31);
     sleep =     (sleep_t)  ((code >> 18) & 1);
     
-    Serial.println("IR code parsed: 0x" + String((unsigned long)code, HEX) + 
-                   " | Power: " + String(power == POWER_TOGGLE ? "TOGGLE" : "KEEP") + 
-                   ", Mode: " + String(mode) + ", Fan: " + String(fan) + ", Notify: " + String(notify ? "yes" : "no") + 
-                   " | Swing_H: " + String(swing_h ? "on" : "off") + ", Swing: " + String(swing ? "on" : "off") + 
-                   ", IFeel: " + String(ifeel ? "on" : "off") + ", Sleep: " + String(sleep ? "on" : "off") + 
-                   ", Temp: " + String(notify ? send_temp + 5 : send_temp + 15));
+    DEBUG_LOG("IR code parsed: 0x" + String((unsigned long)code, HEX) + 
+              " | Power: " + String(power == POWER_TOGGLE ? "TOGGLE" : "KEEP") + 
+              ", Mode: " + String(mode) + ", Fan: " + String(fan) + ", Notify: " + String(notify ? "yes" : "no") + 
+              " | Swing_H: " + String(swing_h ? "on" : "off") + ", Swing: " + String(swing ? "on" : "off") + 
+              ", IFeel: " + String(ifeel ? "on" : "off") + ", Sleep: " + String(sleep ? "on" : "off") + 
+              ", Temp: " + String(notify ? send_temp + 5 : send_temp + 15));
 
     if (power == POWER_TOGGLE) {
         power_setting = !power_real;

--- a/src/IRelectra.h
+++ b/src/IRelectra.h
@@ -11,6 +11,10 @@
 
 #include <stdint.h>
 #include <IRrecv.h>
+#include <WString.h>
+
+// Debug logging callback
+void setIRDebugCallback(void (*callback)(const String&));
 
 enum power_t 
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,18 +30,33 @@ HomieNode stateNode("state", "state","state");
 HomieNode debugNode("debug", "debug","debug");
 #endif
 
-#ifdef ARDUINO_ESP8266_ESP01
-const uint8_t POWER_PIN = 2;
-const uint8_t IR_PIN = 0;
-#else
-const uint8_t POWER_PIN = 5;
-const uint8_t IR_PIN = 4;
-const uint8_t GREEN_LED_PIN = 12;
-const uint8_t RED_LED_PIN = 15;
+// Pin assignments - configure per-environment in platformio.ini build_flags
+// e.g.  -D PIN_IR=23
+#ifndef PIN_POWER
+  #define PIN_POWER 5
+#endif
+#ifndef PIN_IR
+  #define PIN_IR 4
+#endif
+#ifndef PIN_GREEN_LED
+  #define PIN_GREEN_LED 12
+#endif
+#ifndef PIN_RED_LED
+  #define PIN_RED_LED 15
+#endif
+#ifndef PIN_IR_RECV
+  #define PIN_IR_RECV 14
+#endif
+
+const uint8_t POWER_PIN = PIN_POWER;
+const uint8_t IR_PIN = PIN_IR;
+#ifndef ARDUINO_ESP8266_ESP01
+const uint8_t GREEN_LED_PIN = PIN_GREEN_LED;
+const uint8_t RED_LED_PIN = PIN_RED_LED;
 #endif
 
 #ifndef ELECTRAWIFI_NO_IR_RCV
-const uint8_t IR_RECV_PIN = 14;
+const uint8_t IR_RECV_PIN = PIN_IR_RECV;
 #endif
 
 const uint8_t kTimeout = 10;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,15 +7,28 @@
 #include <ArduinoJson.h>
 #include "IRelectra.h"
 
+// Debug logging - controlled by DEBUG_SERIAL and DEBUG_MQTT build flags
+#if DEBUG_SERIAL && DEBUG_MQTT
+  #define DEBUG_LOG(x) do { Serial.println(x); debugNode.setProperty("log").send(x); } while(0)
+#elif DEBUG_SERIAL
+  #define DEBUG_LOG(x) Serial.println(x)
+#elif DEBUG_MQTT
+  #define DEBUG_LOG(x) debugNode.setProperty("log").send(x)
+#else
+  inline void DEBUG_LOG(const String&) { }
+#endif
 
 HomieNode temperatureNode("temperature", "temperature","temperature");
 HomieNode modeNode("mode", "mode","mode");
 HomieNode fanNode("fan", "fan","fan");
 HomieNode swingNode("swing", "swing","swing");
 HomieNode ifeelNode("ifeel", "ifeel","ifeel");
-HomieNode ifeelTempNode("ifeel_temperature", "ifeel_temperature","ifeel_temperature");
+HomieNode ifeelTempNode("ifeel-temperature", "ifeel_temperature","ifeel_temperature");
 HomieNode powerNode("power", "power","power");
 HomieNode stateNode("state", "state","state");
+#if DEBUG_MQTT
+HomieNode debugNode("debug", "debug","debug");
+#endif
 
 #ifdef ARDUINO_ESP8266_ESP01
 const uint8_t POWER_PIN = 2;
@@ -88,16 +101,13 @@ void send_updates() {
   } else {
     swing = "off";
   }
-  //Serial << "AC swing: " << (ac.swing ? "on": "off") << "|" << (ac.swing_h  ? "on": "off") <<endl;
-  //Serial << "Send Update swing: " << swing << endl;
   
-  Serial << "Sending state update: power=" << (ac.power_real ? "on" : "off") 
-         << " mode=" << mode 
-         << " fan=" << fan 
-         << " swing=" << swing 
-         << " temp=" << ac.temperature 
-         << " ifeel=" << (ac.ifeel == IFEEL_ON ? "on" : "off") 
-         << endl;
+  DEBUG_LOG("Sending state update: power=" + String(ac.power_real ? "on" : "off") + 
+         " mode=" + mode + 
+         " fan=" + fan + 
+         " swing=" + swing + 
+         " temp=" + String(ac.temperature) + 
+         " ifeel=" + String(ac.ifeel == IFEEL_ON ? "on" : "off"));
   
   powerNode.setProperty("state").send(ac.power_real ? "on": "off");
   fanNode.setProperty("state").send(fan);
@@ -118,7 +128,7 @@ void loopHandler() {
   if (power_state != ac.power_real) {
     if (power_change_time) {
       if (now - power_change_time > POWER_DEBOUNCE) {
-        Serial << "Power pin state changed: " << (power_state ? "on" : "off") << endl;
+        DEBUG_LOG("Power pin state changed: " + String(power_state ? "on" : "off"));
         ac.power_real = power_state;
         ac.power_setting = power_state;
         powerNode.setProperty("state").send(power_state ? "on": "off");
@@ -135,6 +145,7 @@ void loopHandler() {
   // Send ifeel if relevant
   if (now - ifeel_send_time >= IFEEL_INTERVAL) {
     if (ac.ifeel == IFEEL_ON) {
+      DEBUG_LOG("Sending ifeel temperature: " + String(ac.ifeel_temperature));
       ac.SendElectra(true);
     }
     ifeel_send_time = now;
@@ -155,7 +166,7 @@ void loopHandler() {
     code = DecodeElectraIR(ir_ticks);
     irrecv.resume();
     if (code) {
-      Serial << "IR command received: 0x" << String((unsigned long)code, HEX) << endl;
+      DEBUG_LOG("IR command received: 0x" + String((unsigned long)code, HEX));
       ac.UpdateFromIR(code);
       ac.SendElectra(false);
       send_updates();
@@ -166,13 +177,13 @@ void loopHandler() {
 
 bool powerHandler(const HomieRange& range, const String& value) {
   // This method is called when using the HA actions climate.turn_on and climate.turn_off
-  Serial << "MQTT received: power=" << value << endl;
+  DEBUG_LOG("MQTT received: power=" + value);
   if (value == "on") {
     ac.power_setting = true;
   } else if (value == "off") {
     ac.power_setting = false;
   } else {
-    Serial << "MQTT error: invalid power value" << endl;
+    DEBUG_LOG("MQTT error: invalid power value");
     return false;
   }
   ac.SendElectra(false);
@@ -183,10 +194,10 @@ bool powerHandler(const HomieRange& range, const String& value) {
 }
 
 bool temperatureHandler(const HomieRange& range, const String& value) {
-  Serial << "MQTT received: temperature=" << value << endl;
+  DEBUG_LOG("MQTT received: temperature=" + value);
   uint8_t temp = value.toInt();
   if (temp < 15 || temp > 30) { // setpoint temp has only 4 bits where 15 == 0b0000 and 30 == 0b1111
-    Serial << "MQTT error: temperature out of range (15-30)" << endl;
+    DEBUG_LOG("MQTT error: temperature out of range (15-30)");
     return false;
   }
   ac.temperature = temp;
@@ -198,7 +209,7 @@ bool temperatureHandler(const HomieRange& range, const String& value) {
 bool modeHandler(const HomieRange& range, const String& value) {
   // This method is called when using the HA action climate.set_hvac_mode
   // Since climate.set_hvac_mode can be used to switch between `off` and other modes instead of climate.turn_on/off, it needs to call powerHandler.
-  Serial << "MQTT received: mode=" << value << endl;
+  DEBUG_LOG("MQTT received: mode=" + value);
   if (value == "cool") {
     ac.mode = MODE_COOL;
   } else if (value == "heat") {
@@ -212,14 +223,14 @@ bool modeHandler(const HomieRange& range, const String& value) {
   } else if (value == "off") {
     return powerHandler(range, "off");
   } else {
-    Serial << "MQTT error: invalid mode value" << endl;
+    DEBUG_LOG("MQTT error: invalid mode value");
     return false;
   }
   return powerHandler(range, "on");
 }
 
 bool fanHandler(const HomieRange& range, const String& value) {
-  Serial << "MQTT received: fan=" << value << endl;
+  DEBUG_LOG("MQTT received: fan=" + value);
   if (value == "low") {
     ac.fan = FAN_LOW;
   } else if (value == "med") {
@@ -229,7 +240,7 @@ bool fanHandler(const HomieRange& range, const String& value) {
   } else if (value == "auto") {
     ac.fan = FAN_AUTO;
   } else {
-    Serial << "MQTT error: invalid fan value" << endl;
+    DEBUG_LOG("MQTT error: invalid fan value");
     return false;
   }
   ac.SendElectra(false);
@@ -238,13 +249,13 @@ bool fanHandler(const HomieRange& range, const String& value) {
 }
 
 bool ifeelHandler(const HomieRange& range, const String& value) {
-  Serial << "MQTT received: ifeel=" << value << endl;
+  DEBUG_LOG("MQTT received: ifeel=" + value);
   if (value == "on") {
     ac.ifeel = IFEEL_ON;
   } else if (value == "off") {
     ac.ifeel = IFEEL_OFF;
   } else {
-    Serial << "MQTT error: invalid ifeel value" << endl;
+    DEBUG_LOG("MQTT error: invalid ifeel value");
     return false;
   }
   ac.SendElectra(false);
@@ -253,10 +264,10 @@ bool ifeelHandler(const HomieRange& range, const String& value) {
 }
 
 bool ifeelTempHandler(const HomieRange& range, const String& value) {
-  Serial << "MQTT received: ifeel_temperature=" << value << endl;
+  DEBUG_LOG("MQTT received: ifeel_temperature=" + value);
   uint8_t temp = value.toInt();
   if (temp < 5 || temp > 36) { // ifeel temp has only 5 bits where 0 == 0b00000 and 36 == 0b11111
-    Serial << "MQTT error: ifeel_temperature out of range (5-36)" << endl;
+    DEBUG_LOG("MQTT error: ifeel_temperature out of range (5-36)");
     return false;
   }
   ac.ifeel_temperature = temp;
@@ -265,7 +276,7 @@ bool ifeelTempHandler(const HomieRange& range, const String& value) {
 }
 
 bool swingHandler(const HomieRange& range, const String& value) {
-  Serial << "MQTT received: swing=" << value << endl;
+  DEBUG_LOG("MQTT received: swing=" + value);
   if (value == "on") {
     ac.swing = SWING_ON;
     ac.swing_h = SWING_H_OFF;
@@ -279,7 +290,7 @@ bool swingHandler(const HomieRange& range, const String& value) {
     ac.swing = SWING_OFF;
     ac.swing_h = SWING_H_OFF;
   } else {
-    Serial << "MQTT error: invalid swing value" << endl;
+    DEBUG_LOG("MQTT error: invalid swing value");
     return false;
   }
   ac.SendElectra(false);
@@ -289,11 +300,11 @@ bool swingHandler(const HomieRange& range, const String& value) {
 
 
 bool jsonHandler(const HomieRange& range, const String& value) {
-  Serial << "MQTT received: json=" << value << endl;
+  DEBUG_LOG("MQTT received: json=" + value);
   StaticJsonDocument<200> parsed;
   auto error = deserializeJson(parsed,value);
   if (error) {
-    Serial << "MQTT error: failed to parse JSON" << endl;
+    DEBUG_LOG("MQTT error: failed to parse JSON");
     return false;
   }
 
@@ -379,6 +390,19 @@ void setup() {
   Serial.begin(115200);
   Serial << endl << endl;
   //Homie.disableLogging();
+  
+#if DEBUG_SERIAL || DEBUG_MQTT
+  // Set up IR debug logging callback
+  setIRDebugCallback([](const String& msg) {
+    #if DEBUG_SERIAL
+      Serial.println(msg);
+    #endif
+    #if DEBUG_MQTT
+      debugNode.setProperty("log").send(msg);
+    #endif
+  });
+#endif
+
 #ifdef ARDUINO_ESP8266_ESP01
   Homie.disableLedFeedback();
 #endif
@@ -392,6 +416,9 @@ void setup() {
   powerNode.advertise("state").settable(powerHandler);
   swingNode.advertise("state").settable(swingHandler);
   stateNode.advertise("json").settable(jsonHandler);
+#if DEBUG_MQTT
+  debugNode.advertise("log");
+#endif
   
   pinMode(POWER_PIN, INPUT_PULLUP);
 #ifndef ARDUINO_ESP8266_ESP01

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,6 +90,15 @@ void send_updates() {
   }
   //Serial << "AC swing: " << (ac.swing ? "on": "off") << "|" << (ac.swing_h  ? "on": "off") <<endl;
   //Serial << "Send Update swing: " << swing << endl;
+  
+  Serial << "Sending state update: power=" << (ac.power_real ? "on" : "off") 
+         << " mode=" << mode 
+         << " fan=" << fan 
+         << " swing=" << swing 
+         << " temp=" << ac.temperature 
+         << " ifeel=" << (ac.ifeel == IFEEL_ON ? "on" : "off") 
+         << endl;
+  
   powerNode.setProperty("state").send(ac.power_real ? "on": "off");
   fanNode.setProperty("state").send(fan);
   modeNode.setProperty("state").send(mode);
@@ -113,6 +122,7 @@ void loopHandler() {
         ac.power_real = power_state;
         ac.power_setting = power_state;
         powerNode.setProperty("state").send(power_state ? "on": "off");
+        send_updates();
         power_change_time = 0;
       }
     } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,6 +86,8 @@ void send_updates() {
       mode = "dry";
     } else if (ac.mode == MODE_AUTO) {
       mode = "auto";
+    } else if (ac.mode == MODE_FAN) {
+      mode = "fan_only";
     }
   }
   else {
@@ -218,7 +220,7 @@ bool modeHandler(const HomieRange& range, const String& value) {
     ac.mode = MODE_AUTO;
   } else if (value == "dry") {
     ac.mode = MODE_DRY;
-  } else if (value == "fan") {
+  } else if (value == "fan" || value == "fan_only") {
     ac.mode = MODE_FAN;
   } else if (value == "off") {
     return powerHandler(range, "off");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,6 +109,7 @@ void loopHandler() {
   if (power_state != ac.power_real) {
     if (power_change_time) {
       if (now - power_change_time > POWER_DEBOUNCE) {
+        Serial << "Power pin state changed: " << (power_state ? "on" : "off") << endl;
         ac.power_real = power_state;
         ac.power_setting = power_state;
         powerNode.setProperty("state").send(power_state ? "on": "off");
@@ -144,6 +145,7 @@ void loopHandler() {
     code = DecodeElectraIR(ir_ticks);
     irrecv.resume();
     if (code) {
+      Serial << "IR command received: 0x" << String((unsigned long)code, HEX) << endl;
       ac.UpdateFromIR(code);
       ac.SendElectra(false);
       send_updates();
@@ -154,8 +156,10 @@ void loopHandler() {
 
 
 bool temperatureHandler(const HomieRange& range, const String& value) {
+  Serial << "MQTT received: temperature=" << value << endl;
   uint8_t temp = value.toInt();
   if (temp < 15 || temp > 30) { // setpoint temp has only 4 bits where 15 == 0b0000 and 30 == 0b1111
+    Serial << "MQTT error: temperature out of range (15-30)" << endl;
     return false;
   }
   ac.temperature = temp;
@@ -165,6 +169,7 @@ bool temperatureHandler(const HomieRange& range, const String& value) {
 }
 
 bool modeHandler(const HomieRange& range, const String& value) {
+  Serial << "MQTT received: mode=" << value << endl;
   if (value == "cool") {
     ac.mode = MODE_COOL;
   } else if (value == "heat") {
@@ -176,6 +181,7 @@ bool modeHandler(const HomieRange& range, const String& value) {
   } else if (value == "fan") {
     ac.mode = MODE_FAN;
   } else {
+    Serial << "MQTT error: invalid mode value" << endl;
     return false;
   }
   ac.SendElectra(false);
@@ -184,6 +190,7 @@ bool modeHandler(const HomieRange& range, const String& value) {
 }
 
 bool fanHandler(const HomieRange& range, const String& value) {
+  Serial << "MQTT received: fan=" << value << endl;
   if (value == "low") {
     ac.fan = FAN_LOW;
   } else if (value == "med") {
@@ -193,6 +200,7 @@ bool fanHandler(const HomieRange& range, const String& value) {
   } else if (value == "auto") {
     ac.fan = FAN_AUTO;
   } else {
+    Serial << "MQTT error: invalid fan value" << endl;
     return false;
   }
   ac.SendElectra(false);
@@ -201,11 +209,13 @@ bool fanHandler(const HomieRange& range, const String& value) {
 }
 
 bool ifeelHandler(const HomieRange& range, const String& value) {
+  Serial << "MQTT received: ifeel=" << value << endl;
   if (value == "on") {
     ac.ifeel = IFEEL_ON;
   } else if (value == "off") {
     ac.ifeel = IFEEL_OFF;
   } else {
+    Serial << "MQTT error: invalid ifeel value" << endl;
     return false;
   }
   ac.SendElectra(false);
@@ -214,8 +224,10 @@ bool ifeelHandler(const HomieRange& range, const String& value) {
 }
 
 bool ifeelTempHandler(const HomieRange& range, const String& value) {
+  Serial << "MQTT received: ifeel_temperature=" << value << endl;
   uint8_t temp = value.toInt();
   if (temp < 5 || temp > 36) { // ifeel temp has only 5 bits where 0 == 0b00000 and 36 == 0b11111
+    Serial << "MQTT error: ifeel_temperature out of range (5-36)" << endl;
     return false;
   }
   ac.ifeel_temperature = temp;
@@ -224,7 +236,7 @@ bool ifeelTempHandler(const HomieRange& range, const String& value) {
 }
 
 bool swingHandler(const HomieRange& range, const String& value) {
-  //Serial << "Swing Handler value: " << value << endl;
+  Serial << "MQTT received: swing=" << value << endl;
   if (value == "on") {
     ac.swing = SWING_ON;
     ac.swing_h = SWING_H_OFF;
@@ -238,6 +250,7 @@ bool swingHandler(const HomieRange& range, const String& value) {
     ac.swing = SWING_OFF;
     ac.swing_h = SWING_H_OFF;
   } else {
+    Serial << "MQTT error: invalid swing value" << endl;
     return false;
   }
   ac.SendElectra(false);
@@ -246,11 +259,13 @@ bool swingHandler(const HomieRange& range, const String& value) {
 }
 
 bool powerHandler(const HomieRange& range, const String& value) {
+  Serial << "MQTT received: power=" << value << endl;
   if (value == "on") {
     ac.power_setting = true;
   } else if (value == "off") {
     ac.power_setting = false;
   } else {
+    Serial << "MQTT error: invalid power value" << endl;
     return false;
   }
   ac.SendElectra(false);
@@ -261,9 +276,11 @@ bool powerHandler(const HomieRange& range, const String& value) {
 }
 
 bool jsonHandler(const HomieRange& range, const String& value) {
+  Serial << "MQTT received: json=" << value << endl;
   StaticJsonDocument<200> parsed;
   auto error = deserializeJson(parsed,value);
   if (error) {
+    Serial << "MQTT error: failed to parse JSON" << endl;
     return false;
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,6 +154,23 @@ void loopHandler() {
 #endif
 }
 
+bool powerHandler(const HomieRange& range, const String& value) {
+  // This method is called when using the HA actions climate.turn_on and climate.turn_off
+  Serial << "MQTT received: power=" << value << endl;
+  if (value == "on") {
+    ac.power_setting = true;
+  } else if (value == "off") {
+    ac.power_setting = false;
+  } else {
+    Serial << "MQTT error: invalid power value" << endl;
+    return false;
+  }
+  ac.SendElectra(false);
+  ac.power_real = ac.power_setting;
+  powerNode.setProperty("state").send(ac.power_real ? "on": "off");
+  send_updates();
+  return true;
+}
 
 bool temperatureHandler(const HomieRange& range, const String& value) {
   Serial << "MQTT received: temperature=" << value << endl;
@@ -169,6 +186,8 @@ bool temperatureHandler(const HomieRange& range, const String& value) {
 }
 
 bool modeHandler(const HomieRange& range, const String& value) {
+  // This method is called when using the HA action climate.set_hvac_mode
+  // Since climate.set_hvac_mode can be used to switch between `off` and other modes instead of climate.turn_on/off, it needs to call powerHandler.
   Serial << "MQTT received: mode=" << value << endl;
   if (value == "cool") {
     ac.mode = MODE_COOL;
@@ -180,13 +199,13 @@ bool modeHandler(const HomieRange& range, const String& value) {
     ac.mode = MODE_DRY;
   } else if (value == "fan") {
     ac.mode = MODE_FAN;
+  } else if (value == "off") {
+    return powerHandler(range, "off");
   } else {
     Serial << "MQTT error: invalid mode value" << endl;
     return false;
   }
-  ac.SendElectra(false);
-  send_updates();
-  return true;
+  return powerHandler(range, "on");
 }
 
 bool fanHandler(const HomieRange& range, const String& value) {
@@ -258,22 +277,6 @@ bool swingHandler(const HomieRange& range, const String& value) {
   return true;
 }
 
-bool powerHandler(const HomieRange& range, const String& value) {
-  Serial << "MQTT received: power=" << value << endl;
-  if (value == "on") {
-    ac.power_setting = true;
-  } else if (value == "off") {
-    ac.power_setting = false;
-  } else {
-    Serial << "MQTT error: invalid power value" << endl;
-    return false;
-  }
-  ac.SendElectra(false);
-  ac.power_real = ac.power_setting;
-  powerNode.setProperty("state").send(ac.power_real ? "on": "off");
-  send_updates();
-  return true;
-}
 
 bool jsonHandler(const HomieRange& range, const String& value) {
   Serial << "MQTT received: json=" << value << endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@ HomieNode ifeelNode("ifeel", "ifeel","ifeel");
 HomieNode ifeelTempNode("ifeel-temperature", "ifeel_temperature","ifeel_temperature");
 HomieNode powerNode("power", "power","power");
 HomieNode stateNode("state", "state","state");
+HomieNode rebootNode("reboot", "reboot","reboot");
 #if DEBUG_MQTT
 HomieNode debugNode("debug", "debug","debug");
 #endif
@@ -403,6 +404,16 @@ bool jsonHandler(const HomieRange& range, const String& value) {
   return true;
 }
 
+bool rebootHandler(const HomieRange& range, const String& value) {
+  if (value == "true") {
+    DEBUG_LOG("Rebooting...");
+    ESP.restart();
+    return true;
+  }
+  DEBUG_LOG("MQTT error: invalid reboot value (expected \"true\")");
+  return false;
+}
+
 void setup() {
   Serial.begin(115200);
   Serial << endl << endl;
@@ -433,6 +444,7 @@ void setup() {
   powerNode.advertise("state").settable(powerHandler);
   swingNode.advertise("state").settable(swingHandler);
   stateNode.advertise("json").settable(jsonHandler);
+  rebootNode.advertise("trigger").settable(rebootHandler);
 #if DEBUG_MQTT
   debugNode.advertise("log");
 #endif


### PR DESCRIPTION
**ESP32 Support**
- Added build instructions to README, since homie source code requires some tweaks as with ESP8266
- Added build configuration in platformio.ini for 2 ESP32 boards (plus dependencies conflict solution)

**Debug logs**
- Added debug logs in main parts of the code (state changes, IR processing, etc) and main.cpp and IRelectra.cpp
- Debug logging is supported via serial connection and over MQTT
- Both methods are optional, and configurable by build flags

**Improved handlers logic**
- In the previous behavior, modeHandler handled only the cool\warm\dry modes, and powerHandler handled on\off
- The problem was that HA Climate entity can be also turned off using climate.set_hvac_mode:off, not just climate.turn_off
- The new flow handles this power off method by calling powerHandler from modeHanlder
- Added a call to send_updates in the loopHanlder to sync HA climate mode after using physical IR remote

**i-feel bugfix**
- Homie has some problem with underscore in the MQTT topic
- Renamed ifeel_temperature to ifeel-temperature in main.cpp and updated the README
- Added to README a note that the protocol only supports integer values for temperature,